### PR TITLE
chore: uninstall @types/bn.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1103,15 +1103,6 @@
         "@types/node": "*"
       }
     },
-    "@types/bn.js": {
-      "version": "4.11.5",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.5.tgz",
-      "integrity": "sha512-AEAZcIZga0JgVMHNtl1CprA/hXX7/wPt79AgR4XqaDt7jyj3QWYw6LPoOiznPtugDmlubUnAahMs2PFxGcQrng==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/body-parser": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
   "devDependencies": {
     "@po.et/frost-client": "2.1.0",
     "@po.et/tslint-rules": "2.2.0",
-    "@types/bn.js": "4.11.5",
     "@types/chai": "4.1.7",
     "@types/cheerio": "0.22.10",
     "@types/form-data": "2.2.1",


### PR DESCRIPTION
Now that https://github.com/ethereumjs/ethereumjs-util/issues/199 is solved we should be able to uninstall this dependency.